### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-announcement.yml
+++ b/.github/workflows/update-announcement.yml
@@ -7,6 +7,10 @@
 
 name: Draft announcement
 
+permissions:
+  contents: write
+  actions: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/churchincanberra/churchincanberra.github.io/security/code-scanning/39](https://github.com/churchincanberra/churchincanberra.github.io/security/code-scanning/39)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: write` for committing changes to the repository.
- `actions: read` for using GitHub Actions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `update` job to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
